### PR TITLE
minor fixes in installation instructions and tox

### DIFF
--- a/template/README.md.j2
+++ b/template/README.md.j2
@@ -41,7 +41,7 @@ If you need jupyter lab, install it
 To install, run
 
 ```
-(conda_env) $ pip install -e ".[test,doc]
+(conda_env) $ pip install -e ".[test,doc]"
 ```
 
 To run style checks:

--- a/template/README.md.j2
+++ b/template/README.md.j2
@@ -4,7 +4,7 @@
 ![Coverage Status](https://raw.githubusercontent.com/{{ github_org }}/{{ project_name }}/main/coverage-badge.svg)
 
 <h1 align="center">
-# {{ project_name }}
+{{ project_name }}
 </h1>
 
 <br>

--- a/template/docs/source/conf.py.j2
+++ b/template/docs/source/conf.py.j2
@@ -86,6 +86,10 @@ exclude_patterns = [
     ".ipynb_checkpoints",
 ]
 
+suppress_warnings = [
+    'myst.header'
+]
+
 # -- Options for HTML output
 
 html_theme = "furo"


### PR DESCRIPTION
After trying out the copier template, I came across a few minor errors with the template of the project:

1. Minor typo in installation instructions.
2. Error in `docs` when running `tox` (`tox -e docs`): as the first header is formated in HTML, it’s not recognized by Markdown. This throws an error that the largest headers are formatted as H2. Added a statement in `conf.py` to ignore this header warning. With this, no errors are displayed when running `tox`.
3. Accordingly, deleting `#` before the project name as the header is already formatted as a H1 heading in HTML.


As this will likely come up in every project created from this template, I thought that I can contribute by submitting a PR.